### PR TITLE
Add CMake build and stub replacements for legacy libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,36 @@ Related
 =======
 
 There is also the [Enemy Nations Revival Project](http://groups.google.com/forum) which seems pretty dead though.
+
+
+Building on modern Windows
+==========================
+
+The repository now ships with a CMake build that targets Visual Studio 2022
+and replaces the original proprietary dependencies with source builds and
+open stubs.  To build the game on Windows 10/11:
+
+1. Install [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) with
+   the **Desktop development with C++** workload.  Make sure the optional MFC
+   component is selected.
+2. Install [CMake 3.20+](https://cmake.org/download/).  CMake is also bundled
+   with recent Visual Studio installations.
+3. Open a "x86 Native Tools Command Prompt for VS 2022" (the project still
+   targets Win32) and configure the build:
+
+   ```cmd
+   cmake -S src -B build -A Win32
+   ```
+
+4. Build the solution from the command line or from the generated Visual
+   Studio solution:
+
+   ```cmd
+   cmake --build build --config Release
+   ```
+
+The configuration stage builds the `windward` support library directly from
+the sources under `windward/src` and links in stub implementations for the
+Miles Sound System and VDMPlay networking APIs.  The game executable is
+produced in the `build/Release` directory when building the Release
+configuration.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,131 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(EnemyNations LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_MFC_FLAG 2)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../windward ${CMAKE_BINARY_DIR}/windward)
+
+set(GAME_SOURCES
+    Ai.cpp
+    area.cpp
+    bmbutton.cpp
+    bridge.cpp
+    caicopy.cpp
+    caidata.cpp
+    caigmgr.cpp
+    caigoal.cpp
+    caihex.cpp
+    caiinit.cpp
+    caimap.cpp
+    caimaput.cpp
+    caimgr.cpp
+    caimsg.cpp
+    caiopfor.cpp
+    cairoute.cpp
+    caisavld.cpp
+    caistart.cpp
+    caitask.cpp
+    caitmgr.cpp
+    caiunit.cpp
+    CdLoc.cpp
+    chat.cpp
+    chatbar.cpp
+    chproute.cpp
+    cpathmap.cpp
+    cpathmgr.cpp
+    creatmul.cpp
+    creatsin.cpp
+    credits.cpp
+    cutscene.cpp
+    dlgflic.cpp
+    DlgMsg.cpp
+    DlgReg.cpp
+    Dxfer.cpp
+    event.cpp
+    icons.cpp
+    ipcchat.cpp
+    ipccomm.cpp
+    ipcmsg.cpp
+    ipcplay.cpp
+    ipcread.cpp
+    ipcsend.cpp
+    join.cpp
+    lastplnt.cpp
+    Lastplnt.rc
+    license.cpp
+    loadtruk.cpp
+    main.cpp
+    Mainloop.cpp
+    minerals.cpp
+    movie.cpp
+    netapi.cpp
+    netcmd.cpp
+    new_game.cpp
+    new_unit.cpp
+    newworld.cpp
+    options.cpp
+    pickrace.cpp
+    player.cpp
+    PlyrList.cpp
+    projbase.cpp
+    racedata.cpp
+    relation.cpp
+    research.cpp
+    scenario.cpp
+    sprite.cpp
+    sprtinit.cpp
+    stdafx.cpp
+    terrain.cpp
+    toolbar.cpp
+    tstsnds.cpp
+    unit.cpp
+    unit_wnd.cpp
+    vehicle.cpp
+    Vehmove.cpp
+    vehoppo.cpp
+    VPXFER.CPP
+    world.cpp
+    wrldinit.cpp
+    RES/VERSION.RC
+)
+
+add_executable(EnemyNations WIN32 ${GAME_SOURCES})
+
+if(MSVC)
+    target_compile_options(EnemyNations PRIVATE /utf-8)
+endif()
+
+target_precompile_headers(EnemyNations PRIVATE stdafx.h)
+
+target_include_directories(EnemyNations
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../windward/include
+)
+
+target_compile_definitions(EnemyNations
+    PRIVATE
+        WIN32
+        _WINDOWS
+        _MBCS
+        _AFXDLL
+        VDMPLAY_STATIC
+)
+
+target_link_libraries(EnemyNations
+    PRIVATE
+        windward
+        shlwapi
+        vfw32
+        winmm
+        version
+        comctl32
+        comdlg32
+        user32
+        gdi32
+)
+

--- a/src/VDMPLAY.H
+++ b/src/VDMPLAY.H
@@ -22,7 +22,9 @@
 #endif
 
 #ifdef WIN32
-#ifndef VPSYSTEM
+#if defined(VDMPLAY_STATIC)
+#define VPAPI
+#elif !defined(VPSYSTEM)
 #define VPAPI __declspec(dllimport)
 #else
 #define VPAPI __declspec(dllexport)
@@ -57,6 +59,8 @@ typedef const void FAR *LPCVOID;
 #define VPAPI_VERSION ((VPAPIVERSION_MAJOR << 8) | VPAPIVERSION_MINOR)
 
 #pragma pack(8)
+
+struct LANA_ENUM;
 
 enum VPNOTIFICATION
 {
@@ -494,6 +498,13 @@ BOOL VPAPI vpGetServerAddress(
 BOOL VPAPI vpAdvancedSetup(int protocol);
 
 #endif
+
+int VPAPI vpFetchInt(LPCSTR section, LPCSTR key, int defaultValue);
+void VPAPI vpStoreInt(LPCSTR section, LPCSTR key, int value);
+void VPAPI vpFetchString(LPCSTR section, LPCSTR key, LPCSTR defaultValue, LPSTR buffer, int bufferSize);
+void VPAPI vpStoreString(LPCSTR section, LPCSTR key, LPCSTR value);
+void VPAPI vpMakeIniFile(LPCSTR fileName);
+void VPAPI vpGetLanas(LANA_ENUM* lanaEnum);
 
 }
 

--- a/src/vdmplay.h
+++ b/src/vdmplay.h
@@ -22,7 +22,9 @@
 #endif
 
 #ifdef WIN32
-#ifndef VPSYSTEM
+#if defined(VDMPLAY_STATIC)
+#define VPAPI
+#elif !defined(VPSYSTEM)
 #define VPAPI __declspec(dllimport)
 #else
 #define VPAPI __declspec(dllexport)
@@ -57,6 +59,8 @@ typedef const void FAR *LPCVOID;
 #define VPAPI_VERSION ((VPAPIVERSION_MAJOR << 8) | VPAPIVERSION_MINOR)
 
 #pragma pack(8)
+
+struct LANA_ENUM;
 
 enum VPNOTIFICATION
 {
@@ -494,6 +498,13 @@ BOOL VPAPI vpGetServerAddress(
 BOOL VPAPI vpAdvancedSetup(int protocol);
 
 #endif
+
+int VPAPI vpFetchInt(LPCSTR section, LPCSTR key, int defaultValue);
+void VPAPI vpStoreInt(LPCSTR section, LPCSTR key, int value);
+void VPAPI vpFetchString(LPCSTR section, LPCSTR key, LPCSTR defaultValue, LPSTR buffer, int bufferSize);
+void VPAPI vpStoreString(LPCSTR section, LPCSTR key, LPCSTR value);
+void VPAPI vpMakeIniFile(LPCSTR fileName);
+void VPAPI vpGetLanas(LANA_ENUM* lanaEnum);
 
 }
 

--- a/windward/CMakeLists.txt
+++ b/windward/CMakeLists.txt
@@ -1,0 +1,78 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(WindwardSupport LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_MFC_FLAG 2)
+
+set(WINDWARD_SOURCES
+    src/Acmutil.cpp
+    src/BITBUFFE.CPP
+    src/BTREE.CPP
+    src/Bpecodec.cpp
+    src/DAVIDINL.CPP
+    src/DIRCORE.CPP
+    src/Datafile.cpp
+    src/DlgMsg.cpp
+    src/FIXPOINT.CPP
+    src/FLCCTRL.CPP
+    src/GLOBAL.CPP
+    src/HUFFMANC.CPP
+    src/INIT.CPP
+    src/LZSSCODE.CPP
+    src/LZWCODEC.CPP
+    src/MMIO.CPP
+    src/MSG_BOX.CPP
+    src/Music.cpp
+    src/RAND.CPP
+    src/SCANLIST.CPP
+    src/STDAFX.CPP
+    src/STREXT.CPP
+    src/Threads.cpp
+    src/apppalet.cpp
+    src/blt.cpp
+    src/cache.cpp
+    src/codec.cpp
+    src/dib.cpp
+    src/logging.CPP
+    src/mss_stub.cpp
+    src/subclass.cpp
+    src/vdmplay_stub.cpp
+    src/wndbase.cpp
+)
+
+add_library(windward STATIC ${WINDWARD_SOURCES})
+
+if(MSVC)
+    target_compile_options(windward PRIVATE /utf-8)
+endif()
+
+target_include_directories(windward
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+
+target_precompile_headers(windward PRIVATE src/STDAFX.H)
+
+target_compile_definitions(windward
+    PRIVATE
+        WIN32
+        _WINDOWS
+        _MBCS
+        VDMPLAY_STATIC
+)
+
+target_link_libraries(windward
+    PUBLIC
+        winmm
+        ddraw
+        dsound
+        dxguid
+        msacm32
+)
+

--- a/windward/include/mssw.h
+++ b/windward/include/mssw.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <windows.h>
+#include <mmsystem.h>
+
+extern "C" {
+
+using S32 = long;
+using U32 = unsigned long;
+using HSAMPLE = void*;
+using HDIGDRIVER = void*;
+using HMDIDRIVER = void*;
+using HSEQUENCE = void*;
+
+constexpr S32 YES = 1;
+constexpr S32 NO = 0;
+constexpr S32 DIG_USE_WAVEOUT = 0;
+constexpr S32 DIG_PCM_SIGN = 1;
+constexpr S32 DIG_F_MONO_8 = 0;
+
+constexpr S32 SMP_DONE = 0;
+constexpr S32 SMP_PLAYING = 1;
+
+constexpr S32 SEQ_STOPPED = 0;
+constexpr S32 SEQ_PLAYING = 1;
+
+using AIL_sample_callback = void (WINAPI*)(HSAMPLE);
+using AIL_sequence_callback = void (WINAPI*)(HSEQUENCE);
+
+S32 AIL_startup();
+void AIL_shutdown();
+void AIL_serve();
+S32 AIL_set_preference(S32 number, S32 value);
+S32 AIL_waveOutOpen(HDIGDRIVER* driver, LPSTR device, U32 flags, LPWAVEFORMAT waveFormat);
+void AIL_waveOutClose(HDIGDRIVER driver);
+void AIL_lock();
+void AIL_unlock();
+HSAMPLE AIL_allocate_sample_handle(HDIGDRIVER driver);
+void AIL_release_sample_handle(HSAMPLE sample);
+void AIL_init_sample(HSAMPLE sample);
+void AIL_set_sample_user_data(HSAMPLE sample, S32 index, S32 value);
+S32 AIL_sample_user_data(HSAMPLE sample, S32 index);
+void AIL_set_sample_volume(HSAMPLE sample, S32 volume);
+void AIL_set_sample_pan(HSAMPLE sample, S32 pan);
+void AIL_set_sample_playback_rate(HSAMPLE sample, S32 rate);
+void AIL_set_sample_type(HSAMPLE sample, S32 format, S32 flags);
+void AIL_register_EOB_callback(HSAMPLE sample, AIL_sample_callback callback);
+void AIL_register_EOS_callback(HSAMPLE sample, AIL_sample_callback callback);
+void AIL_set_sample_loop_count(HSAMPLE sample, S32 loops);
+S32 AIL_sample_buffer_ready(HSAMPLE sample);
+void AIL_set_sample_address(HSAMPLE sample, const void* begin, U32 length);
+void AIL_load_sample_buffer(HSAMPLE sample, S32 bufferId, char* data, S32 len);
+void AIL_start_sample(HSAMPLE sample);
+void AIL_end_sample(HSAMPLE sample);
+S32 AIL_sample_status(HSAMPLE sample);
+void AIL_set_digital_master_volume(HDIGDRIVER driver, S32 volume);
+void AIL_DLL_version(LPSTR buffer, S32 length);
+HMDIDRIVER AIL_midiOutOpen(HMDIDRIVER* driver, LPSTR device, S32 deviceId);
+void AIL_midiOutClose(HMDIDRIVER driver);
+void AIL_set_XMIDI_master_volume(HMDIDRIVER driver, S32 volume);
+HSEQUENCE AIL_allocate_sequence_handle(HMDIDRIVER driver);
+void AIL_release_sequence_handle(HSEQUENCE sequence);
+void AIL_init_sequence(HSEQUENCE sequence, const void* data, S32 track);
+void AIL_register_sequence_callback(HSEQUENCE sequence, AIL_sequence_callback callback);
+void AIL_start_sequence(HSEQUENCE sequence);
+void AIL_end_sequence(HSEQUENCE sequence);
+S32 AIL_sequence_status(HSEQUENCE sequence);
+void AIL_set_sequence_user_data(HSEQUENCE sequence, S32 index, S32 value);
+S32 AIL_digital_handle_release(HDIGDRIVER driver);
+S32 AIL_digital_handle_reacquire(HDIGDRIVER driver);
+S32 AIL_MIDI_handle_release(HMDIDRIVER driver);
+S32 AIL_MIDI_handle_reacquire(HMDIDRIVER driver);
+
+}
+

--- a/windward/src/mss_stub.cpp
+++ b/windward/src/mss_stub.cpp
@@ -1,0 +1,349 @@
+#include "stdafx.h"
+#include "mssw.h"
+
+#include <array>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace {
+struct SampleStub {
+    HDIGDRIVER owner = nullptr;
+    std::array<LONG_PTR, 4> userData{};
+    AIL_sample_callback eob = nullptr;
+    AIL_sample_callback eos = nullptr;
+    S32 loopCount = 0;
+    S32 status = SMP_DONE;
+};
+
+struct SequenceStub {
+    HMDIDRIVER owner = nullptr;
+    AIL_sequence_callback callback = nullptr;
+    S32 status = SEQ_STOPPED;
+    std::array<LONG_PTR, 4> userData{};
+};
+
+struct DriverStub {
+    S32 volume = 127;
+};
+
+struct MidiDriverStub {
+    S32 volume = 127;
+};
+
+std::mutex& mutex() {
+    static std::mutex instance;
+    return instance;
+}
+
+std::unordered_map<HSAMPLE, SampleStub>& samples() {
+    static std::unordered_map<HSAMPLE, SampleStub> instance;
+    return instance;
+}
+
+std::unordered_map<HSEQUENCE, SequenceStub>& sequences() {
+    static std::unordered_map<HSEQUENCE, SequenceStub> instance;
+    return instance;
+}
+
+std::unordered_map<HDIGDRIVER, DriverStub>& drivers() {
+    static std::unordered_map<HDIGDRIVER, DriverStub> instance;
+    return instance;
+}
+
+std::unordered_map<HMDIDRIVER, MidiDriverStub>& midiDrivers() {
+    static std::unordered_map<HMDIDRIVER, MidiDriverStub> instance;
+    return instance;
+}
+
+HSAMPLE makeSample(HDIGDRIVER driver) {
+    static uintptr_t nextId = 1;
+    HSAMPLE handle = reinterpret_cast<HSAMPLE>(nextId++);
+    samples().emplace(handle, SampleStub{driver});
+    return handle;
+}
+
+HSEQUENCE makeSequence(HMDIDRIVER driver) {
+    static uintptr_t nextId = 1;
+    HSEQUENCE handle = reinterpret_cast<HSEQUENCE>(nextId++);
+    sequences().emplace(handle, SequenceStub{driver});
+    return handle;
+}
+
+void destroySample(HSAMPLE sample) {
+    samples().erase(sample);
+}
+
+void destroySequence(HSEQUENCE sequence) {
+    sequences().erase(sequence);
+}
+
+DriverStub& ensureDriver(HDIGDRIVER driver) {
+    auto& map = drivers();
+    auto it = map.find(driver);
+    if (it == map.end()) {
+        it = map.emplace(driver, DriverStub{}).first;
+    }
+    return it->second;
+}
+
+MidiDriverStub& ensureMidiDriver(HMDIDRIVER driver) {
+    auto& map = midiDrivers();
+    auto it = map.find(driver);
+    if (it == map.end()) {
+        it = map.emplace(driver, MidiDriverStub{}).first;
+    }
+    return it->second;
+}
+
+} // namespace
+
+extern "C" {
+
+S32 AIL_startup() {
+    return 0;
+}
+
+void AIL_shutdown() {}
+
+void AIL_serve() {}
+
+S32 AIL_set_preference(S32, S32) {
+    return 0;
+}
+
+S32 AIL_waveOutOpen(HDIGDRIVER* driver, LPSTR, U32, LPWAVEFORMAT) {
+    std::lock_guard<std::mutex> lock(mutex());
+    if (!driver) {
+        return -1;
+    }
+    static uintptr_t nextId = 1;
+    HDIGDRIVER handle = reinterpret_cast<HDIGDRIVER>(nextId++);
+    drivers().emplace(handle, DriverStub{});
+    *driver = handle;
+    return 0;
+}
+
+void AIL_waveOutClose(HDIGDRIVER driver) {
+    std::lock_guard<std::mutex> lock(mutex());
+    drivers().erase(driver);
+}
+
+void AIL_lock() {}
+
+void AIL_unlock() {}
+
+HSAMPLE AIL_allocate_sample_handle(HDIGDRIVER driver) {
+    std::lock_guard<std::mutex> lock(mutex());
+    return makeSample(driver);
+}
+
+void AIL_release_sample_handle(HSAMPLE sample) {
+    std::lock_guard<std::mutex> lock(mutex());
+    destroySample(sample);
+}
+
+void AIL_init_sample(HSAMPLE sample) {
+    std::lock_guard<std::mutex> lock(mutex());
+    auto it = samples().find(sample);
+    if (it != samples().end()) {
+        it->second.status = SMP_DONE;
+    }
+}
+
+void AIL_set_sample_user_data(HSAMPLE sample, S32 index, S32 value) {
+    std::lock_guard<std::mutex> lock(mutex());
+    auto it = samples().find(sample);
+    if (it == samples().end()) {
+        return;
+    }
+    if (index < 0 || index >= static_cast<S32>(it->second.userData.size())) {
+        return;
+    }
+    it->second.userData[static_cast<size_t>(index)] = value;
+}
+
+S32 AIL_sample_user_data(HSAMPLE sample, S32 index) {
+    std::lock_guard<std::mutex> lock(mutex());
+    auto it = samples().find(sample);
+    if (it == samples().end()) {
+        return 0;
+    }
+    if (index < 0 || index >= static_cast<S32>(it->second.userData.size())) {
+        return 0;
+    }
+    return static_cast<S32>(it->second.userData[static_cast<size_t>(index)]);
+}
+
+void AIL_set_sample_volume(HSAMPLE, S32) {}
+
+void AIL_set_sample_pan(HSAMPLE, S32) {}
+
+void AIL_set_sample_playback_rate(HSAMPLE, S32) {}
+
+void AIL_set_sample_type(HSAMPLE, S32, S32) {}
+
+void AIL_register_EOB_callback(HSAMPLE sample, AIL_sample_callback callback) {
+    std::lock_guard<std::mutex> lock(mutex());
+    auto it = samples().find(sample);
+    if (it != samples().end()) {
+        it->second.eob = callback;
+    }
+}
+
+void AIL_register_EOS_callback(HSAMPLE sample, AIL_sample_callback callback) {
+    std::lock_guard<std::mutex> lock(mutex());
+    auto it = samples().find(sample);
+    if (it != samples().end()) {
+        it->second.eos = callback;
+    }
+}
+
+void AIL_set_sample_loop_count(HSAMPLE sample, S32 loops) {
+    std::lock_guard<std::mutex> lock(mutex());
+    auto it = samples().find(sample);
+    if (it != samples().end()) {
+        it->second.loopCount = loops;
+    }
+}
+
+S32 AIL_sample_buffer_ready(HSAMPLE) {
+    return 1;
+}
+
+void AIL_set_sample_address(HSAMPLE, const void*, U32) {}
+
+void AIL_load_sample_buffer(HSAMPLE, S32, char*, S32) {}
+
+void AIL_start_sample(HSAMPLE sample) {
+    std::lock_guard<std::mutex> lock(mutex());
+    auto it = samples().find(sample);
+    if (it != samples().end()) {
+        it->second.status = SMP_PLAYING;
+    }
+}
+
+void AIL_end_sample(HSAMPLE sample) {
+    std::lock_guard<std::mutex> lock(mutex());
+    auto it = samples().find(sample);
+    if (it == samples().end()) {
+        return;
+    }
+    it->second.status = SMP_DONE;
+    if (it->second.eos) {
+        it->second.eos(sample);
+    }
+}
+
+S32 AIL_sample_status(HSAMPLE sample) {
+    std::lock_guard<std::mutex> lock(mutex());
+    auto it = samples().find(sample);
+    if (it == samples().end()) {
+        return SMP_DONE;
+    }
+    return it->second.status;
+}
+
+void AIL_set_digital_master_volume(HDIGDRIVER driver, S32 volume) {
+    std::lock_guard<std::mutex> lock(mutex());
+    ensureDriver(driver).volume = volume;
+}
+
+void AIL_DLL_version(LPSTR buffer, S32 length) {
+    if (!buffer || length <= 0) {
+        return;
+    }
+    const std::string version = "Stub Miles 0.1";
+    lstrcpynA(buffer, version.c_str(), length);
+}
+
+HMDIDRIVER AIL_midiOutOpen(HMDIDRIVER* driver, LPSTR, S32) {
+    std::lock_guard<std::mutex> lock(mutex());
+    static uintptr_t nextId = 1;
+    HMDIDRIVER handle = reinterpret_cast<HMDIDRIVER>(nextId++);
+    midiDrivers().emplace(handle, MidiDriverStub{});
+    if (driver) {
+        *driver = handle;
+    }
+    return handle;
+}
+
+void AIL_midiOutClose(HMDIDRIVER driver) {
+    std::lock_guard<std::mutex> lock(mutex());
+    midiDrivers().erase(driver);
+}
+
+void AIL_set_XMIDI_master_volume(HMDIDRIVER driver, S32 volume) {
+    std::lock_guard<std::mutex> lock(mutex());
+    ensureMidiDriver(driver).volume = volume;
+}
+
+HSEQUENCE AIL_allocate_sequence_handle(HMDIDRIVER driver) {
+    std::lock_guard<std::mutex> lock(mutex());
+    return makeSequence(driver);
+}
+
+void AIL_release_sequence_handle(HSEQUENCE sequence) {
+    std::lock_guard<std::mutex> lock(mutex());
+    destroySequence(sequence);
+}
+
+void AIL_init_sequence(HSEQUENCE sequence, const void*, S32) {
+    std::lock_guard<std::mutex> lock(mutex());
+    sequences()[sequence].status = SEQ_STOPPED;
+}
+
+void AIL_register_sequence_callback(HSEQUENCE sequence, AIL_sequence_callback callback) {
+    std::lock_guard<std::mutex> lock(mutex());
+    sequences()[sequence].callback = callback;
+}
+
+void AIL_start_sequence(HSEQUENCE sequence) {
+    std::lock_guard<std::mutex> lock(mutex());
+    sequences()[sequence].status = SEQ_PLAYING;
+    if (auto cb = sequences()[sequence].callback) {
+        cb(sequence);
+    }
+}
+
+void AIL_end_sequence(HSEQUENCE sequence) {
+    std::lock_guard<std::mutex> lock(mutex());
+    sequences()[sequence].status = SEQ_STOPPED;
+}
+
+S32 AIL_sequence_status(HSEQUENCE sequence) {
+    std::lock_guard<std::mutex> lock(mutex());
+    auto it = sequences().find(sequence);
+    if (it == sequences().end()) {
+        return SEQ_STOPPED;
+    }
+    return it->second.status;
+}
+
+void AIL_set_sequence_user_data(HSEQUENCE sequence, S32 index, S32 value) {
+    std::lock_guard<std::mutex> lock(mutex());
+    auto& data = sequences()[sequence].userData;
+    if (index >= 0 && index < static_cast<S32>(data.size())) {
+        data[static_cast<size_t>(index)] = value;
+    }
+}
+
+S32 AIL_digital_handle_release(HDIGDRIVER) {
+    return TRUE;
+}
+
+S32 AIL_digital_handle_reacquire(HDIGDRIVER) {
+    return TRUE;
+}
+
+S32 AIL_MIDI_handle_release(HMDIDRIVER) {
+    return TRUE;
+}
+
+S32 AIL_MIDI_handle_reacquire(HMDIDRIVER) {
+    return TRUE;
+}
+
+} // extern "C"
+

--- a/windward/src/vdmplay_stub.cpp
+++ b/windward/src/vdmplay_stub.cpp
@@ -1,0 +1,324 @@
+#include "stdafx.h"
+#include "vdmplay.h"
+
+#include <nb30.h>
+
+#include <algorithm>
+#include <map>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+
+namespace {
+
+struct VpHandle {
+    DWORD version = VPAPI_VERSION;
+    bool enumerating = false;
+};
+
+struct VpSession {
+    VpHandle* owner = nullptr;
+    VPPLAYERID nextPlayer = VP_FIRSTPLAYER;
+    BOOL visible = TRUE;
+};
+
+struct ConfigStore {
+    std::map<std::string, std::string> values;
+};
+
+std::mutex& globalMutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+std::unordered_set<VpHandle*>& handleStore() {
+    static std::unordered_set<VpHandle*> handles;
+    return handles;
+}
+
+std::unordered_set<VpSession*>& sessionStore() {
+    static std::unordered_set<VpSession*> sessions;
+    return sessions;
+}
+
+ConfigStore& config() {
+    static ConfigStore store;
+    return store;
+}
+
+std::string makeKey(LPCSTR section, LPCSTR key) {
+    std::string result;
+    if (section && *section) {
+        result.assign(section);
+    }
+    result.push_back(':');
+    if (key && *key) {
+        result.append(key);
+    }
+    return result;
+}
+
+VpHandle* toHandle(VPHANDLE handle) {
+    return reinterpret_cast<VpHandle*>(handle);
+}
+
+VpSession* toSession(VPSESSIONHANDLE session) {
+    return reinterpret_cast<VpSession*>(session);
+}
+
+void eraseSessionsForHandle(VpHandle* handle) {
+    auto& sessions = sessionStore();
+    for (auto it = sessions.begin(); it != sessions.end();) {
+        if ((*it)->owner == handle) {
+            delete *it;
+            it = sessions.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+} // namespace
+
+extern "C" {
+
+DWORD VPAPI vpGetVersion() {
+    return VPAPI_VERSION;
+}
+
+DWORD VPAPI vpSupportedTransports() {
+    return 1u << VPT_TCP;
+}
+
+VPHANDLE VPAPI vpStartup(DWORD, LPCVPGUID, DWORD, DWORD, UINT, LPCVOID) {
+    std::lock_guard<std::mutex> lock(globalMutex());
+    auto* handle = new VpHandle{};
+    handleStore().insert(handle);
+    return reinterpret_cast<VPHANDLE>(handle);
+}
+
+BOOL VPAPI vpCleanup(VPHANDLE handle) {
+    std::lock_guard<std::mutex> lock(globalMutex());
+    auto* data = toHandle(handle);
+    if (!data) {
+        return TRUE;
+    }
+    eraseSessionsForHandle(data);
+    handleStore().erase(data);
+    delete data;
+    return TRUE;
+}
+
+BOOL VPAPI vpEnumSessions(VPHANDLE handle, HWND, BOOL dontAutoStop, LPCVOID) {
+    std::lock_guard<std::mutex> lock(globalMutex());
+    auto* data = toHandle(handle);
+    if (!data) {
+        return FALSE;
+    }
+    data->enumerating = dontAutoStop ? true : false;
+    return TRUE;
+}
+
+BOOL VPAPI vpStopEnumSessions(VPHANDLE handle) {
+    std::lock_guard<std::mutex> lock(globalMutex());
+    auto* data = toHandle(handle);
+    if (!data) {
+        return FALSE;
+    }
+    data->enumerating = false;
+    return TRUE;
+}
+
+BOOL VPAPI vpStartRegistrationServer(VPHANDLE, HWND, LPCVOID) {
+    return TRUE;
+}
+
+BOOL VPAPI vpStopRegistrationServer(VPHANDLE) {
+    return TRUE;
+}
+
+BOOL VPAPI vpEnumPlayers(VPHANDLE, HWND, LPCVPSESSIONID, LPCVOID) {
+    return TRUE;
+}
+
+VPSESSIONHANDLE VPAPI vpCreateSession(VPHANDLE handle, HWND, LPCSTR, DWORD, LPCVOID) {
+    std::lock_guard<std::mutex> lock(globalMutex());
+    auto* data = toHandle(handle);
+    if (!data) {
+        return nullptr;
+    }
+    auto* session = new VpSession{data};
+    sessionStore().insert(session);
+    return reinterpret_cast<VPSESSIONHANDLE>(session);
+}
+
+BOOL VPAPI vpSetSessionVisibility(VPSESSIONHANDLE session, BOOL visibility) {
+    std::lock_guard<std::mutex> lock(globalMutex());
+    auto* data = toSession(session);
+    if (!data) {
+        return FALSE;
+    }
+    data->visible = visibility;
+    return TRUE;
+}
+
+BOOL VPAPI vpGetSessionInfo(VPSESSIONHANDLE, LPVPSESSIONINFO info) {
+    if (info) {
+        ZeroMemory(info, sizeof(*info));
+    }
+    return TRUE;
+}
+
+BOOL VPAPI vpGetSessionInfoById(VPHANDLE, HWND, LPCVPSESSIONID, LPCVOID) {
+    return FALSE;
+}
+
+BOOL VPAPI vpUpdateSessionData(VPSESSIONHANDLE, LPCVOID) {
+    return TRUE;
+}
+
+VPSESSIONHANDLE VPAPI vpJoinSession(VPHANDLE handle, HWND, LPCVPSESSIONID, LPCSTR, DWORD, LPCVOID) {
+    std::lock_guard<std::mutex> lock(globalMutex());
+    auto* data = toHandle(handle);
+    if (!data) {
+        return nullptr;
+    }
+    auto* session = new VpSession{data};
+    sessionStore().insert(session);
+    return reinterpret_cast<VPSESSIONHANDLE>(session);
+}
+
+BOOL VPAPI vpAddPlayer(VPSESSIONHANDLE session, LPCSTR, DWORD, LPCVOID, LPVPPLAYERID playerId) {
+    std::lock_guard<std::mutex> lock(globalMutex());
+    auto* data = toSession(session);
+    if (!data) {
+        return FALSE;
+    }
+    if (playerId) {
+        *playerId = data->nextPlayer++;
+    }
+    return TRUE;
+}
+
+BOOL VPAPI vpSendData(VPSESSIONHANDLE, VPPLAYERID, VPPLAYERID, LPCVOID, DWORD, DWORD, LPCVOID) {
+    return TRUE;
+}
+
+BOOL VPAPI vpCloseSession(VPSESSIONHANDLE session, LPCVOID) {
+    std::lock_guard<std::mutex> lock(globalMutex());
+    auto* data = toSession(session);
+    if (!data) {
+        return TRUE;
+    }
+    sessionStore().erase(data);
+    delete data;
+    return TRUE;
+}
+
+DWORD VPAPI vpGetAddressString(VPHANDLE, LPCVPNETADDRESS, LPSTR buffer, DWORD bufferSize) {
+    const std::string text = "offline";
+    if (buffer && bufferSize > 0) {
+        lstrcpynA(buffer, text.c_str(), static_cast<int>(bufferSize));
+    }
+    return static_cast<DWORD>(text.size());
+}
+
+BOOL VPAPI vpGetAddress(VPHANDLE, LPVPNETADDRESS address) {
+    if (address) {
+        ZeroMemory(address, sizeof(*address));
+        lstrcpynA(address->machineAddress, "offline", sizeof(address->machineAddress));
+    }
+    return TRUE;
+}
+
+BOOL VPAPI vpStartFT(VPSESSIONHANDLE, LPVPFTINFO) {
+    return FALSE;
+}
+
+BOOL VPAPI vpAcceptFT(VPSESSIONHANDLE, LPVPFTINFO) {
+    return FALSE;
+}
+
+BOOL VPAPI vpSendBlock(VPSESSIONHANDLE, LPVPFTINFO, LPCVOID, DWORD) {
+    return FALSE;
+}
+
+BOOL VPAPI vpGetBlock(VPSESSIONHANDLE, LPVPFTINFO, LPVOID, DWORD) {
+    return FALSE;
+}
+
+BOOL VPAPI vpStopFT(VPSESSIONHANDLE, LPVPFTINFO) {
+    return FALSE;
+}
+
+BOOL VPAPI vpAcknowledge(VPHANDLE, LPCVPMESSAGE) {
+    return TRUE;
+}
+
+BOOL VPAPI vpInvitePlayer(VPSESSIONHANDLE, VPPLAYERID) {
+    return TRUE;
+}
+
+BOOL VPAPI vpRejectPlayer(VPSESSIONHANDLE, VPPLAYERID) {
+    return TRUE;
+}
+
+BOOL VPAPI vpKillPlayer(VPSESSIONHANDLE, VPPLAYERID) {
+    return TRUE;
+}
+
+void VPAPI vpAdvDialog(HWND, int, BOOL) {}
+
+void VPAPI vpAbortWait(VPHANDLE) {}
+
+BOOL VPAPI vpGetServerAddress(VPHANDLE, LPVPNETADDRESS address) {
+    return vpGetAddress(nullptr, address);
+}
+
+BOOL VPAPI vpAdvancedSetup(int) {
+    return TRUE;
+}
+
+int VPAPI vpFetchInt(LPCSTR section, LPCSTR key, int defaultValue) {
+    std::lock_guard<std::mutex> lock(globalMutex());
+    auto it = config().values.find(makeKey(section, key));
+    if (it == config().values.end()) {
+        return defaultValue;
+    }
+    try {
+        return std::stoi(it->second);
+    } catch (...) {
+        return defaultValue;
+    }
+}
+
+void VPAPI vpStoreInt(LPCSTR section, LPCSTR key, int value) {
+    std::lock_guard<std::mutex> lock(globalMutex());
+    config().values[makeKey(section, key)] = std::to_string(value);
+}
+
+void VPAPI vpFetchString(LPCSTR section, LPCSTR key, LPCSTR defaultValue, LPSTR buffer, int bufferSize) {
+    if (!buffer || bufferSize <= 0) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(globalMutex());
+    auto it = config().values.find(makeKey(section, key));
+    const std::string& value = (it == config().values.end()) ? std::string(defaultValue ? defaultValue : "") : it->second;
+    lstrcpynA(buffer, value.c_str(), bufferSize);
+}
+
+void VPAPI vpStoreString(LPCSTR section, LPCSTR key, LPCSTR value) {
+    std::lock_guard<std::mutex> lock(globalMutex());
+    config().values[makeKey(section, key)] = value ? value : "";
+}
+
+void VPAPI vpMakeIniFile(LPCSTR) {}
+
+void VPAPI vpGetLanas(LANA_ENUM* lanaEnum) {
+    if (lanaEnum) {
+        lanaEnum->length = 0;
+    }
+}
+
+} // extern "C"
+


### PR DESCRIPTION
## Summary
- add a CMake-based Win32 build that enumerates the original enations sources and links the rebuilt windward library
- replace the proprietary Miles Sound System and VDMPlay dependencies with in-tree stub implementations and compile the windward utilities from source
- document modern Windows build prerequisites and workflow in README

## Testing
- not run (Windows-only build workflow)