### PR TITLE
Automate CMake source discovery and document Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,31 +34,50 @@ There is also the [Enemy Nations Revival Project](http://groups.google.com/forum
 Building on modern Windows
 ==========================
 
-The repository now ships with a CMake build that targets Visual Studio 2022
-and replaces the original proprietary dependencies with source builds and
-open stubs.  To build the game on Windows 10/11:
+The repository now ships with a first-class CMake toolchain that generates a
+Visual Studio 2022 solution on demand.  The project file list is no longer
+hand-maintained: the `src/CMakeLists.txt` script parses `src/enations.dsp`
+directly, ensuring that every source and resource listed in the legacy
+project is built automatically.
 
-1. Install [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) with
-   the **Desktop development with C++** workload.  Make sure the optional MFC
-   component is selected.
-2. Install [CMake 3.20+](https://cmake.org/download/).  CMake is also bundled
-   with recent Visual Studio installations.
-3. Open a "x86 Native Tools Command Prompt for VS 2022" (the project still
-   targets Win32) and configure the build:
+Prerequisites
+-------------
+
+* Windows 10 or Windows 11.
+* [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) with the
+  **Desktop development with C++** workload and the optional MFC component.
+* [CMake 3.20 or newer](https://cmake.org/download/).  The Visual Studio
+  installer ships with a compatible CMake build.
+
+Configuring and building
+------------------------
+
+1. Launch a "x86 Native Tools Command Prompt for VS 2022" (the game is still
+   a Win32 application).
+2. Generate the Visual Studio solution and project files:
 
    ```cmd
-   cmake -S src -B build -A Win32
+   cmake -S src -B build -G "Visual Studio 17 2022" -A Win32
    ```
 
-4. Build the solution from the command line or from the generated Visual
-   Studio solution:
+3. Build from the command prompt or open the generated `build/EnemyNations.sln`
+   in the Visual Studio IDE:
 
    ```cmd
    cmake --build build --config Release
    ```
 
-The configuration stage builds the `windward` support library directly from
-the sources under `windward/src` and links in stub implementations for the
-Miles Sound System and VDMPlay networking APIs.  The game executable is
-produced in the `build/Release` directory when building the Release
-configuration.
+Open-source replacements for proprietary middleware
+---------------------------------------------------
+
+The original build linked against proprietary libraries such as
+`shmfc4m.lib`, `shlw32m.lib`, `wind40.lib`, `mss32.lib`, and `vdmplay.lib`.
+Those dependencies have been replaced by the in-tree `windward` static
+library, which now compiles from source and provides stubbed
+implementations of the Miles Sound System (`mss_stub.cpp`) and VDMPlay
+(`vdmplay_stub.cpp`).  No external binary blobs are required to link the
+game when using the new build system.
+
+When the build completes, Visual Studio places the game executable in the
+`build/Release` directory (or `build/Debug` when selecting the Debug
+configuration).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,89 +9,75 @@ set(CMAKE_MFC_FLAG 2)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../windward ${CMAKE_BINARY_DIR}/windward)
 
-set(GAME_SOURCES
-    Ai.cpp
-    area.cpp
-    bmbutton.cpp
-    bridge.cpp
-    caicopy.cpp
-    caidata.cpp
-    caigmgr.cpp
-    caigoal.cpp
-    caihex.cpp
-    caiinit.cpp
-    caimap.cpp
-    caimaput.cpp
-    caimgr.cpp
-    caimsg.cpp
-    caiopfor.cpp
-    cairoute.cpp
-    caisavld.cpp
-    caistart.cpp
-    caitask.cpp
-    caitmgr.cpp
-    caiunit.cpp
-    CdLoc.cpp
-    chat.cpp
-    chatbar.cpp
-    chproute.cpp
-    cpathmap.cpp
-    cpathmgr.cpp
-    creatmul.cpp
-    creatsin.cpp
-    credits.cpp
-    cutscene.cpp
-    dlgflic.cpp
-    DlgMsg.cpp
-    DlgReg.cpp
-    Dxfer.cpp
-    event.cpp
-    icons.cpp
-    ipcchat.cpp
-    ipccomm.cpp
-    ipcmsg.cpp
-    ipcplay.cpp
-    ipcread.cpp
-    ipcsend.cpp
-    join.cpp
-    lastplnt.cpp
-    Lastplnt.rc
-    license.cpp
-    loadtruk.cpp
-    main.cpp
-    Mainloop.cpp
-    minerals.cpp
-    movie.cpp
-    netapi.cpp
-    netcmd.cpp
-    new_game.cpp
-    new_unit.cpp
-    newworld.cpp
-    options.cpp
-    pickrace.cpp
-    player.cpp
-    PlyrList.cpp
-    projbase.cpp
-    racedata.cpp
-    relation.cpp
-    research.cpp
-    scenario.cpp
-    sprite.cpp
-    sprtinit.cpp
-    stdafx.cpp
-    terrain.cpp
-    toolbar.cpp
-    tstsnds.cpp
-    unit.cpp
-    unit_wnd.cpp
-    vehicle.cpp
-    Vehmove.cpp
-    vehoppo.cpp
-    VPXFER.CPP
-    world.cpp
-    wrldinit.cpp
-    RES/VERSION.RC
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/enations.dsp ENATIONS_DSP_CONTENT)
+string(REGEX MATCHALL "SOURCE=\\.\\\\([^\\r\\n]+)" ENATIONS_DSP_MATCHES "${ENATIONS_DSP_CONTENT}")
+
+file(
+    GLOB_RECURSE
+    ENATIONS_SOURCE_CANDIDATES
+    RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    CONFIGURE_DEPENDS
+    *.c
+    *.C
+    *.cxx
+    *.cpp
+    *.CPP
+    *.rc
+    *.RC
 )
+
+set(_VALID_EXTENSIONS .c .cpp .cxx .rc)
+set(GAME_SOURCES)
+foreach(_entry IN LISTS ENATIONS_DSP_MATCHES)
+    string(REGEX REPLACE "SOURCE=\\.\\\\([^\\r\\n]+)" "\\1" _relative "${_entry}")
+    string(REPLACE "\\\" "\"" _relative "${_relative}")
+    string(REPLACE "\\\\" "/" _relative "${_relative}")
+    string(TOLOWER "${_relative}" _relative_lower)
+    get_filename_component(_ext "${_relative_lower}" EXT)
+
+    set(_ext_valid OFF)
+    foreach(_valid_ext IN LISTS _VALID_EXTENSIONS)
+        if(_ext STREQUAL _valid_ext)
+            set(_ext_valid ON)
+            break()
+        endif()
+    endforeach()
+
+    if(NOT _ext_valid)
+        continue()
+    endif()
+
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_relative}")
+        set(_resolved "${_relative}")
+    else()
+        set(_resolved "")
+        foreach(_candidate IN LISTS ENATIONS_SOURCE_CANDIDATES)
+            string(TOLOWER "${_candidate}" _candidate_lower)
+            if(_candidate_lower STREQUAL _relative_lower)
+                set(_resolved "${_candidate}")
+                break()
+            endif()
+        endforeach()
+        if(_resolved STREQUAL "")
+            message(FATAL_ERROR "Unable to resolve source '${_relative}' listed in enations.dsp")
+        endif()
+    endif()
+
+    list(APPEND GAME_SOURCES "${_resolved}")
+endforeach()
+
+list(REMOVE_DUPLICATES GAME_SOURCES)
+
+if(GAME_SOURCES STREQUAL "")
+    message(FATAL_ERROR "No source files were discovered in enations.dsp")
+endif()
+
+set(GAME_SOURCES_ABSOLUTE)
+foreach(_src IN LISTS GAME_SOURCES)
+    list(APPEND GAME_SOURCES_ABSOLUTE "${CMAKE_CURRENT_SOURCE_DIR}/${_src}")
+endforeach()
+
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${GAME_SOURCES_ABSOLUTE})
 
 add_executable(EnemyNations WIN32 ${GAME_SOURCES})
 


### PR DESCRIPTION
## Summary
- teach the Enemy Nations CMake project to parse `enations.dsp` so every legacy game source and resource is included automatically
- keep the Visual Studio solution layout organized by mirroring the on-disk tree via `source_group`
- refresh the Windows 10/11 build instructions to highlight the new workflow and the in-tree replacements for proprietary libraries

## Testing
- Not run (Windows-only toolchain)