### PR TITLE
Finalize modern renderer cleanup

### DIFF
--- a/windward/include/dib.h
+++ b/windward/include/dib.h
@@ -167,7 +167,6 @@ public:
 	BOOL								IsInRange( BYTE const *, int iBytes ) const;	
 	int								GetOffset( int x, int y ) { return GetRow( y ) * GetPitch() + x * GetBytesPerPixel(); }
 
-	LPDIRECTDRAWSURFACE			GetDDSurface();
 
 //--------------------------------------------------------------------------
 //	
@@ -254,18 +253,13 @@ private:
 	LONG						  m_lDirPitch;				// Pitch * direction
 	CBLTFormat::DIB_TYPE	  m_eType;
 	HDC						  m_hDCDib;	
-	HBITMAP					  m_hOrigBm;				// the original bitmap attached to hDCWinG
-	HBITMAP					  m_hTextBm;				// the original bitmap attached to hDCWinG
-	BITMAPINFO256			  m_bmi;						// WinG DIB header
-	DDSURFACEDESC			  m_ddOffSurfDesc;		// off-screen surface desc
-	LPDIRECTDRAWSURFACE	  m_pddsurfaceBack;		// off-screen surface (the bitmap)
-	HRESULT					  m_hRes;
+	HBITMAP					  m_hOrigBm;				// the original bitmap attached to m_hDCDib
+	HBITMAP					  m_hTextBm;				// the original bitmap attached to m_hDCDib
+	BITMAPINFO256			  m_bmi;						// Cached BITMAPINFO for the backing surface
 	Ptr< BITMAPINFO256 >	  m_ptrbmiIdentity;
 	int						  m_iLock;
 	BOOL						  m_bBitmapSelected;
 
-	Ptr< CWinG >			  m_ptrwing;
-	Ptr< CDirectDraw >	  m_ptrdirectdraw;
 };
 
 
@@ -315,27 +309,6 @@ inline CDIBHDC::~CDIBHDC()
 	m_pdib->ReleaseDC();
 }
 
-//-------------------------------------------------------------------------
-// CDIB::GetDDSurface
-//-------------------------------------------------------------------------
-inline LPDIRECTDRAWSURFACE
-CDIB::GetDDSurface()
-{
-	ASSERT( CBLTFormat::DIB_DIRECTDRAW == m_eType );
-   ASSERT( m_pddsurfaceBack );
-
-	m_hRes = m_pddsurfaceBack->IsLost();
-
-	if ( m_hRes == DDERR_SURFACELOST )
-		m_hRes = m_pddsurfaceBack->Restore();
-
-	if ( FAILED( m_hRes ))
-		;	// GGFIXIT: throw
-
-	return m_pddsurfaceBack;
-}
-
-/////////////////////////////////////////////////////////////////////////////
 // init a CDIB with a DIB
 inline void CDIB::SetBits ( BITMAPFILEHEADER * pBfhSrc)
 {


### PR DESCRIPTION
## Summary
- Replaced the legacy WinG/DirectDraw scaffolding with a new `CModernRenderer` implementation built on Direct2D in `windward/include/BLT.H` and `windward/src/blt.cpp`. The class handles device creation, swap-chain-sized render targets, fullscreen toggling, and DIB blitting through `BlitFromDIB`.
- Updated `CBLTFormat` logic (`windward/include/BLT.H`, `windward/src/blt.cpp`) to prefer the new renderer and default to 32-bit color.
- Refactored `CDIB` to drop all WinG/DirectDraw dependencies (`windward/include/dib.h`, `windward/src/dib.cpp`). `Resize`, `BitBlt`, `StretchBlt`, `Lock`, `Unlock`, `GetDC`, and `ReleaseDC` now operate with Direct2D/standard GDI paths, and palette synchronization was simplified.
- Adjusted `windward/src/FLCCTRL.CPP` and `src/lastplnt.cpp` to acknowledge the new `DIB_RENDERER` enum value instead of the removed DirectDraw/Wing constants.
- Removed the lingering DirectDraw surface cleanup, reworked `CDIB::NewPalette` to update the cached palette data, and tightened the related comments so they reference the new renderer rather than WinG.
- Updated the radar mask generation in `src/world.cpp` to stretch into a renderer-format DIB and derive edge spans from true-color samples instead of relying on 8-bit palette indices.

## Testing
- Not run (pending integration on Windows).


------
https://chatgpt.com/codex/tasks/task_e_68deb2211c6c8321bc22dabdc53b6954