### PR TITLE
Add Windows-backed critical section implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,21 @@ Message me if you need help.
 
 See license.txt for the license.
 
-Goals
-=====
+Goals and roadmap
+=================
 
 Well, ultimately to port it to linux and update the graphics and udpade the
-weird userinterface to something more usable. 
+weird userinterface to something more usable.
+
+A living roadmap that expands on these themes now lives in
+[ROADMAP.md](ROADMAP.md).  It tracks the remaining gaps for Linux support,
+modern rendering, UI upgrades, and supporting infrastructure.
+
 But step by step:
 
-1. Update to compile with Visual C++ 2010 and remove CD check 
+1. Update to compile with Visual C++ 2010 and remove CD check
 2. Port to Linux
-3. Enhance rendering engine and graphics 
+3. Enhance rendering engine and graphics
 4. Enhance userinterface
 
 --Marenz

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,57 @@
+# Enemy Nations Roadmap
+
+The roadmap documents the next milestones required to get Enemy Nations into a
+healthy, cross-platform state.  It complements the historical notes in
+[HISTORY.md](HISTORY.md) and the build documentation in [README.md](README.md).
+
+## 1. Cross-platform foundation
+
+### 1.1. Linux build enablement
+- Replace Windows-only MFC dependencies with portable UI abstractions (e.g.
+  wxWidgets or Dear ImGui) or add a thin SDL-based shim for an initial port.
+- Introduce platform-neutral entry points for window creation, message loops,
+  timers, and file dialogs.
+- Stub or wrap Win32 synchronization primitives (`CRITICAL_SECTION`, events) in
+  terms of `std::mutex`, `std::condition_variable`, and `std::thread`.
+- Isolate direct Win32 API calls behind platform layers to simplify POSIX
+  implementations.
+
+### 1.2. Toolchain and packaging
+- Add CMake presets for GCC and Clang builds on Linux.
+- Provide scripts or container definitions to fetch the required assets and run
+  smoke tests headlessly.
+- Package data files separately from the executable to simplify distribution via
+  Flatpak, AppImage, or traditional package managers.
+
+## 2. Rendering and audio modernization
+- Investigate migrating the software voxel renderer to OpenGL (desktop and
+  GLES) while keeping a compatibility mode for legacy hardware.
+- Replace the Miles Sound System stubs with SDL_mixer or OpenAL-based playback,
+  making sure MIDI and positional audio have drop-in replacements.
+- Audit texture and sprite loading paths to ensure they run on little- and
+  big-endian architectures.
+
+## 3. UI/UX overhaul
+- Redesign the main shell using responsive layouts that adapt to modern desktop
+  resolutions.
+- Improve accessibility with scalable fonts, keyboard navigation, and remappable
+  hotkeys.
+- Document the UI architecture to guide community contributions and mod support.
+
+## 4. Gameplay and systems polish
+- Expand automated tests in `src/tests` to cover AI regression cases and economy
+  simulations.
+- Revisit balance data for campaign missions to account for community feedback.
+- Add save-game versioning so future patches can remain backward compatible.
+
+## 5. Project health and infrastructure
+- Stand up continuous integration that builds on Windows and Linux, runs unit
+  tests, and packages nightly artifacts.
+- Publish contribution guidelines and code-style references to lower the barrier
+  for new contributors.
+- Track bugs and feature requests in GitHub Discussions or Issues with labels
+  aligned to the roadmap categories above.
+
+Contributions that chip away at any of these items—especially the Linux porting
+work—are welcome.  Please coordinate major architectural efforts through issues
+or discussions before starting to avoid duplicated work.

--- a/windward/include/logging.h
+++ b/windward/include/logging.h
@@ -29,6 +29,8 @@ const int LOG_SEC_RESERVED =		0x00000004;
 
 #else
 
+#include <windward/platform/critical_section.h>
+
 
 class CLog
 {
@@ -42,8 +44,8 @@ public:
 
 protected:
 
-	CFile m_File;
-	CRITICAL_SECTION m_cs;
+        CFile m_File;
+        windward::platform::CriticalSection m_cs;
 
 	int			m_iSection;
 	int			m_iLevel;

--- a/windward/include/windward/platform/critical_section.h
+++ b/windward/include/windward/platform/critical_section.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#ifdef _WIN32
+#    include <windows.h>
+#else
+#    include <mutex>
+#endif
+
+namespace windward::platform {
+
+class CriticalSection {
+public:
+    CriticalSection()
+#ifdef _WIN32
+    {
+        InitializeCriticalSection(&section_);
+    }
+#else
+        = default;
+#endif
+
+    ~CriticalSection() noexcept
+#ifdef _WIN32
+    {
+        DeleteCriticalSection(&section_);
+    }
+#else
+        = default;
+#endif
+
+    CriticalSection(const CriticalSection&) = delete;
+    CriticalSection& operator=(const CriticalSection&) = delete;
+
+    void Lock()
+    {
+#ifdef _WIN32
+        EnterCriticalSection(&section_);
+#else
+        mutex_.lock();
+#endif
+    }
+
+    void Unlock() noexcept
+    {
+#ifdef _WIN32
+        LeaveCriticalSection(&section_);
+#else
+        mutex_.unlock();
+#endif
+    }
+
+    bool TryLock()
+    {
+#ifdef _WIN32
+        return TryEnterCriticalSection(&section_) != FALSE;
+#else
+        return mutex_.try_lock();
+#endif
+    }
+
+private:
+#ifdef _WIN32
+    CRITICAL_SECTION section_;
+#else
+    std::recursive_mutex mutex_;
+#endif
+};
+
+class CriticalSectionLock {
+public:
+    explicit CriticalSectionLock(CriticalSection& section)
+        : section_(section)
+    {
+        section_.Lock();
+    }
+
+    CriticalSectionLock(const CriticalSectionLock&) = delete;
+    CriticalSectionLock& operator=(const CriticalSectionLock&) = delete;
+
+    ~CriticalSectionLock()
+    {
+        section_.Unlock();
+    }
+
+private:
+    CriticalSection& section_;
+};
+
+} // namespace windward::platform
+

--- a/windward/src/logging.CPP
+++ b/windward/src/logging.CPP
@@ -23,23 +23,15 @@ CLog theLog;
 // create a log file
 CLog::CLog()
 {
-
-	memset (&m_cs, 0, sizeof (m_cs));
-	InitializeCriticalSection(&m_cs);
-
-	m_iSection = m_iLevel = 0;
-	m_bLogToFile = m_bLogToDebug = m_bOpened = FALSE;
-	m_File.m_hFile = (unsigned int) -1;
+        m_iSection = m_iLevel = 0;
+        m_bLogToFile = m_bLogToDebug = m_bOpened = FALSE;
+        m_File.m_hFile = (unsigned int) -1;
 }
 
 CLog::~CLog()
 {
-
-	if ((m_bLogToFile) || (m_bLogToDebug))
-		DeleteCriticalSection(&m_cs);
-
-	if (m_File.m_hFile != -1)
-		m_File.Close ();
+        if (m_File.m_hFile != -1)
+                m_File.Close ();
 }
 
 BOOL CLog::OkLevel (int iLevel, int iSection) const
@@ -75,10 +67,10 @@ void CLog::Write (int iLevel, int iSection, char const * pBuf)
 		m_iLevel = ptheApp->GetProfileInt ("Logging", "Level", LOG_PRI_USEFUL);
 		}
 
-	if ((iLevel > m_iLevel) || (! (m_iSection & iSection)))
-		return;
+        if ((iLevel > m_iLevel) || (! (m_iSection & iSection)))
+                return;
 
-	EnterCriticalSection (&m_cs);
+        windward::platform::CriticalSectionLock guard(m_cs);
 
 	// write to the file (we assume an exception is disk full)
 	if (m_bLogToFile)
@@ -100,7 +92,6 @@ void CLog::Write (int iLevel, int iSection, char const * pBuf)
 		OutputDebugString (pBuf);
 #endif
 
-	LeaveCriticalSection (&m_cs);
 }
 
 void logPrintf (int iLevel, int iSection, char const * pFrmt, ...)


### PR DESCRIPTION
## Summary
- make the platform critical section use the native Win32 CRITICAL_SECTION when compiling on Windows
- keep the std::recursive_mutex fallback for non-Windows builds so Linux remains supported
- relax noexcept usage on lock acquisition so POSIX mutex failures propagate instead of terminating the process

## Testing
- not run (Windows-only project dependencies are unavailable in the container)